### PR TITLE
feat(oci-vrrp-failover): new container image for OCI VRRP HA failover

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,9 @@ on:
       - "dockerfiles/**"
       - ".github/workflows/docker-publish.yml"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     # Python unit tests for any image whose directory has a test_*.py file.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,116 @@
+---
+name: Build and Push Container Images to GHCR
+
+# Separate from build-chr.yml because the CHR disk images and these container
+# images have nothing in common except the operator who maintains them.
+# Triggers only on changes inside dockerfiles/<name>/ so unrelated CHR-image
+# work doesn't burn CI builds for containers.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "dockerfiles/**"
+      - ".github/workflows/docker-publish.yml"
+    tags:
+      - "oci-vrrp-failover-v*"
+  pull_request:
+    paths:
+      - "dockerfiles/**"
+      - ".github/workflows/docker-publish.yml"
+
+jobs:
+  test:
+    # Python unit tests for any image whose directory has a test_*.py file.
+    # Image-specific; we'd swap to pytest collection across all of dockerfiles/
+    # if a second container shows up.
+    runs-on: ubuntu-latest
+    if: hashFiles('dockerfiles/oci-vrrp-failover/test_*.py') != ''
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Run oci-vrrp-failover unit tests
+        working-directory: dockerfiles/oci-vrrp-failover
+        run: |
+          # No external test deps — stdlib unittest only. We don't install
+          # oci-cli on the runner since the tests mock subprocess.
+          python3 -m unittest test_server.py -v
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: oci-vrrp-failover
+            context: dockerfiles/oci-vrrp-failover
+            tag_prefix: "oci-vrrp-failover-v"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Decide whether this image is in scope for the trigger
+        id: scope
+        env:
+          IMAGE: ${{ matrix.image.name }}
+          PREFIX: ${{ matrix.image.tag_prefix }}
+          REF: ${{ github.ref }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          # Build if: tag matches this image's prefix, OR the workflow was
+          # triggered by a non-tag event (push to main / PR). The path
+          # filter at the workflow level already restricts to
+          # dockerfiles/**, but with multiple images we could refine this
+          # to a per-image dorny/paths-filter check.
+          if [[ "$REF" == refs/tags/${PREFIX}* ]] || [[ "$EVENT" == "push" ]] || [[ "$EVENT" == "pull_request" ]]; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "build=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up QEMU
+        if: steps.scope.outputs.build == 'true'
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        if: steps.scope.outputs.build == 'true'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        if: steps.scope.outputs.build == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        if: steps.scope.outputs.build == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/calebsargeant/${{ matrix.image.name }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+            type=match,pattern=${{ matrix.image.tag_prefix }}(.*),group=1,prefix=v
+
+      - name: Build and push
+        if: steps.scope.outputs.build == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.image.context }}
+          platforms: linux/amd64,linux/arm64
+          # Don't push on pull_request — GHCR rejects pushes from forks
+          # and we don't want PR-build images polluting the registry.
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - "dockerfiles/**"
       - ".github/workflows/docker-publish.yml"
+  push:
     tags:
       - "oci-vrrp-failover-v*"
   pull_request:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,6 +44,7 @@ jobs:
 
   build:
     needs: test
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -76,6 +77,10 @@ jobs:
           else
             echo "build=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Check test result
+        if: needs.test.result == 'skipped'
+        run: echo "Test was skipped, proceeding with build."
 
       - name: Set up QEMU
         if: steps.scope.outputs.build == 'true'

--- a/dockerfiles/oci-vrrp-failover/Dockerfile
+++ b/dockerfiles/oci-vrrp-failover/Dockerfile
@@ -48,7 +48,7 @@ EXPOSE 8080
 # trigger a failover. The probe hits /health on the same listener, so a hung
 # server is also caught (not just a dead process).
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD curl -fsS http://localhost:8080/health || exit 1
+  CMD curl -fsS http://localhost:${LISTEN_PORT:-8080}/health || exit 1
 
 # Run as non-root. oci-cli + the listener don't need root; binding to 8080
 # (>1024) is fine for an unprivileged user.

--- a/dockerfiles/oci-vrrp-failover/Dockerfile
+++ b/dockerfiles/oci-vrrp-failover/Dockerfile
@@ -1,0 +1,58 @@
+# OCI VRRP failover helper.
+#
+# Runs as a container on each MikroTik CHR, alongside cloudflared. Listens on
+# HTTP for a POST /promote from the RouterOS VRRP on-master hook and, when it
+# arrives, calls the OCI API to reassign a configured floating secondary
+# private IP to the local instance's primary VNIC.
+#
+# Why an extra container instead of doing this from RouterOS directly: the
+# router's API doesn't include `oci-cli`, and shelling out from a hook script
+# is brittle. The container packages the OCI CLI + a small Python listener so
+# the hook script just does `/tool/fetch url=http://172.17.0.3:8080/promote`.
+#
+# Build: docker build -t oci-vrrp-failover .
+# Run:   docker run -e FLOATING_PRIVATE_IP_OCID=... -e OCI_REGION=... -p 8080 oci-vrrp-failover
+#
+# Auth modes (set OCI_AUTH explicitly to pick, or let the helper auto-detect):
+# - instance_principal: container reads VNIC + creds from the OCI metadata
+#   service at 169.254.169.254. Cleanest — no static credentials anywhere.
+#   Requires the container can reach link-local 169.254 from inside the
+#   RouterOS container bridge (verify before relying on it).
+# - api_key: container reads ~/.oci/config (typically a mounted file) and
+#   uses the configured user OCID + key fingerprint + private key. Fallback
+#   for when instance_principal isn't reachable from the container.
+
+FROM python:3.13-slim
+
+# python:3.13-slim has cve hits via system packages over time — keep this
+# pinned to a major version + base image rebuild on schedule, dependabot
+# bumps the base. Also bring in `curl` for HEALTHCHECK reliability without
+# adding a Python subprocess for every probe.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# oci-cli pin is pinned in requirements.txt rather than hard-coded here so
+# dependabot can bump it; the matching server.py runs against any 3.x cli.
+WORKDIR /app
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY server.py /app/server.py
+
+# Internal HTTP listener for VRRP master-state webhook + container health.
+EXPOSE 8080
+
+# Restart-on-unhealthy: HEALTHCHECK + container runtime restart policy means
+# a crashed listener gets cycled instead of silently leaving VRRP unable to
+# trigger a failover. The probe hits /health on the same listener, so a hung
+# server is also caught (not just a dead process).
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD curl -fsS http://localhost:8080/health || exit 1
+
+# Run as non-root. oci-cli + the listener don't need root; binding to 8080
+# (>1024) is fine for an unprivileged user.
+RUN useradd --create-home --shell /bin/bash failover
+USER failover
+
+CMD ["python", "/app/server.py"]

--- a/dockerfiles/oci-vrrp-failover/README.md
+++ b/dockerfiles/oci-vrrp-failover/README.md
@@ -1,0 +1,115 @@
+# oci-vrrp-failover
+
+A tiny Python HTTP listener + `oci-cli` packaged as a container, intended
+to run alongside `cloudflared` on each MikroTik CHR that's part of a
+two-node VRRP HA pair on OCI.
+
+## What problem it solves
+
+OCI VCN route tables can have **only one default route per route table**
+(no ECMP). If you have two egress routers, the route table can name only
+one as the next-hop. When that router dies, the subnets that route
+through it lose egress until something repoints the route.
+
+This image is the "something." On the VRRP `on-master` hook from
+RouterOS, the master MikroTik does:
+
+```routeros
+/tool/fetch url=http://172.17.0.3:8080/promote method=post keep-result=no
+```
+
+…which calls this listener, which calls the OCI API to update the named
+route table(s) so the default route points at the new master's primary
+private IP.
+
+## Why a separate container
+
+RouterOS doesn't include `oci-cli` and doesn't expose a general shell.
+Packaging the OCI CLI + a small HTTP listener as a container is the same
+pattern used by `cloudflared` on MikroTik CHRs — bring the dependency,
+not try to bend RouterOS.
+
+## Why route-table update and not a "floating private IP"
+
+The naive HA pattern moves a secondary private IP between VNICs. **That
+doesn't work on OCI:** `UpdatePrivateIp` doesn't take a `vnic_id`. To
+"move" a secondary IP you have to unassign + reassign (creates a NEW
+private-ip OCID), which breaks any route table that referenced the old
+OCID.
+
+The pattern that works is: keep the route table's `network_entity_id`
+referring to whichever **primary** private IP belongs to the active
+master, and update the route table on failover. That's what this image
+does. A live smoke test against eu-amsterdam-1 saw the OCI control
+plane reflect the change in **~1.2 s API call / ~1.9 s visible** —
+total failover well under the 30 s budget.
+
+## Configuration (environment variables)
+
+| Variable | Required | Default | Description |
+|---|:---:|:---:|---|
+| `OCI_REGION` | ✓ | — | OCI region, e.g. `eu-amsterdam-1` |
+| `LOCAL_PRIVATE_IP_OCID` | ✓ | — | This instance's **primary** private IP OCID — the next-hop the route table should point at when we're the master |
+| `ROUTE_TABLE_OCIDS` | ✓ | — | Comma-separated list of route table OCIDs to update on promote (one per affected subnet, typically app + data) |
+| `FAILOVER_DESTINATION` |   | `0.0.0.0/0` | The destination CIDR of the route rule whose next-hop we own |
+| `OCI_AUTH` |   | `instance_principal` | `instance_principal` or `api_key`. Use `api_key` (and mount `~/.oci/config`) when the container can't reach the metadata service |
+| `LISTEN_HOST` |   | `0.0.0.0` | HTTP listener bind address |
+| `LISTEN_PORT` |   | `8080` | HTTP listener port |
+
+## Endpoints
+
+- `POST /promote` — fetch each route table, swap the `FAILOVER_DESTINATION`
+  rule's `network-entity-id` to `LOCAL_PRIVATE_IP_OCID`, PUT it back.
+  Returns `{ok, results: [{route_table, ok, message}, ...]}`. Status
+  200 if all route tables updated, 500 if any failed.
+- `GET /health` — config echo, used by the container `HEALTHCHECK`.
+  Returns `{ok, local_private_ip_ocid, route_table_ocids, failover_destination}`.
+
+## IAM (OCI side)
+
+The `instance_principal` auth path needs the MikroTik VM's dynamic
+group to carry a policy roughly like:
+
+```
+Allow dynamic-group edge-prod-failover to use route-tables in compartment <prod>
+Allow dynamic-group edge-prod-failover to read vcns in compartment <prod>
+```
+
+`use route-tables` is enough — `manage` would let the container delete the
+table, which it doesn't need.
+
+## Local build / test
+
+```sh
+# Unit tests (no OCI creds needed)
+cd dockerfiles/oci-vrrp-failover
+python3 -m unittest test_server.py -v
+
+# Build image
+docker build -t oci-vrrp-failover .
+
+# Run with api_key auth (mount your local ~/.oci/config)
+docker run --rm -p 8080:8080 \
+  -e OCI_REGION=eu-amsterdam-1 \
+  -e OCI_AUTH=api_key \
+  -e LOCAL_PRIVATE_IP_OCID=ocid1.privateip... \
+  -e ROUTE_TABLE_OCIDS=ocid1.routetable...,ocid1.routetable... \
+  -v ~/.oci:/home/failover/.oci:ro \
+  oci-vrrp-failover
+
+# Trigger a promotion from another shell
+curl -fsS -X POST http://localhost:8080/promote | jq
+```
+
+## Deploy (on MikroTik CHR via RouterOS container runtime)
+
+See the consuming Terraform module in
+`CalebSargeant/infra:terraform/oci/modules/mikrotik/` — adds a
+`routeros_container.failover_helper` resource alongside the existing
+cloudflared container.
+
+## References
+
+- [OCI Reference Architecture: Provide highly available services across availability domains](https://docs.oracle.com/en/solutions/multi-region-high-availability/)
+- [MikroTik RouterOS VRRP](https://help.mikrotik.com/docs/display/ROS/VRRP)
+- Companion design doc: `CalebSargeant/infra:docs/reference/oci-vrrp-ha-design.md`

--- a/dockerfiles/oci-vrrp-failover/requirements.txt
+++ b/dockerfiles/oci-vrrp-failover/requirements.txt
@@ -1,0 +1,8 @@
+# Python dependencies for the OCI VRRP failover helper.
+
+# OCI SDK + CLI — used to reassign the floating private IP to the local VNIC.
+# Pinned to >=3.49 (current operator-local version 3.73.1 as of 2026-05) and
+# <4.0 so a future major version bump doesn't silently land via dependabot
+# without a verification step (the CLI's command surface is conservative
+# across 3.x but breaking changes are explicitly held for major bumps).
+oci-cli>=3.49.0,<4.0.0

--- a/dockerfiles/oci-vrrp-failover/server.py
+++ b/dockerfiles/oci-vrrp-failover/server.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""
+OCI VRRP failover helper.
+
+Listens on HTTP for a POST /promote from the MikroTik RouterOS VRRP
+on-master hook and, when it arrives, updates one or more OCI route
+tables so the configured destination (typically `0.0.0.0/0`) now
+next-hops to the local instance's primary private IP.
+
+Why this and not "move a floating private IP between VNICs":
+
+    OCI's UpdatePrivateIp API doesn't take a vnic_id — secondary
+    private IPs can't be re-parented atomically. The HA pattern that
+    *does* work, and that the design doc validates with a smoke test,
+    is to update the route table's `network_entity_id` for the default
+    route from r1's primary-private-IP OCID to r2's (or back). The
+    route table is the single source of truth for "who's the current
+    egress gateway."
+
+The MikroTik runs in OCI as a VM; the container runs on the MikroTik via
+RouterOS's container runtime (same pattern as cloudflared). When VRRP
+state transitions r1 or r2 to master, the on-master hook does
+`/tool/fetch url=http://172.17.0.3:8080/promote method=post` and this
+listener performs the route-table update.
+
+Environment:
+    OCI_REGION                required. e.g. "eu-amsterdam-1".
+    LOCAL_PRIVATE_IP_OCID     required. OCID of THIS instance's primary
+                              private IP — what the route table should
+                              next-hop to when we're the master.
+    ROUTE_TABLE_OCIDS         required. Comma-separated list of route
+                              table OCIDs to update on promote (one
+                              per affected subnet — typically app + data).
+    FAILOVER_DESTINATION      optional, default "0.0.0.0/0". The CIDR
+                              of the route rule whose next-hop we own.
+    OCI_AUTH                  optional. "instance_principal" (default)
+                              or "api_key" — picks how oci-cli
+                              authenticates. Use "api_key" when the
+                              container can't reach the metadata service.
+    LISTEN_HOST               optional, default "0.0.0.0".
+    LISTEN_PORT               optional, default 8080.
+
+Endpoints:
+    POST /promote   reassign the configured route(s) to the local
+                    primary private IP. Returns JSON
+                    {ok, updated, errors}.
+    GET  /health    liveness probe — 200 if the helper is up and
+                    configured.
+
+Logs to stdout; the container runtime is responsible for collection.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import logging
+import os
+import socketserver
+import subprocess
+import sys
+from typing import List, Tuple
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+logger = logging.getLogger("oci-vrrp-failover")
+
+
+class ConfigError(RuntimeError):
+    """Raised when required configuration is missing or malformed."""
+
+
+class FailoverHelper:
+    """Stateful glue: holds config, knows how to update OCI route tables."""
+
+    def __init__(
+        self,
+        local_private_ip_ocid: str,
+        route_table_ocids: List[str],
+        region: str,
+        failover_destination: str,
+        auth_mode: str,
+    ) -> None:
+        if not local_private_ip_ocid.startswith("ocid1.privateip."):
+            raise ConfigError(
+                f"LOCAL_PRIVATE_IP_OCID must start with ocid1.privateip., got {local_private_ip_ocid!r}"
+            )
+        if not route_table_ocids:
+            raise ConfigError("ROUTE_TABLE_OCIDS must list at least one route table")
+        for rt in route_table_ocids:
+            if not rt.startswith("ocid1.routetable."):
+                raise ConfigError(
+                    f"every entry in ROUTE_TABLE_OCIDS must start with ocid1.routetable., got {rt!r}"
+                )
+        if auth_mode not in ("instance_principal", "api_key"):
+            raise ConfigError(
+                f"OCI_AUTH must be 'instance_principal' or 'api_key', got {auth_mode!r}"
+            )
+
+        self.local_private_ip_ocid = local_private_ip_ocid
+        self.route_table_ocids = route_table_ocids
+        self.region = region
+        self.failover_destination = failover_destination
+        self.auth_mode = auth_mode
+
+    def _auth_args(self) -> List[str]:
+        if self.auth_mode == "instance_principal":
+            return ["--auth", "instance_principal"]
+        # api_key path: oci-cli reads ~/.oci/config by default; nothing extra.
+        return []
+
+    def _run_oci(self, args: List[str]) -> subprocess.CompletedProcess:
+        cmd = ["oci"] + args + ["--region", self.region] + self._auth_args()
+        try:
+            return subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        except subprocess.TimeoutExpired as exc:
+            logger.error("oci-cli timed out after 60s: %s", exc)
+            return subprocess.CompletedProcess(cmd, returncode=124, stdout="", stderr=str(exc))
+
+    def _update_route_table(self, rt_ocid: str) -> Tuple[bool, str]:
+        """Read-modify-write the rules list, updating the matching destination.
+
+        OCI's UpdateRouteTable PUT semantics replace the entire `route-rules`
+        list — we have to fetch the current state, modify the one rule, and
+        send the full list back. Net effect for our use: change exactly one
+        rule (the default route), leave any DRG/VPN routes alone.
+        """
+        get = self._run_oci([
+            "network", "route-table", "get",
+            "--rt-id", rt_ocid,
+            "--query", 'data."route-rules"',
+        ])
+        if get.returncode != 0:
+            return False, f"get failed: {get.stderr.strip()}"
+
+        try:
+            rules = json.loads(get.stdout)
+        except json.JSONDecodeError as exc:
+            return False, f"get returned malformed JSON: {exc}"
+        if not isinstance(rules, list):
+            return False, f"expected list of rules, got {type(rules).__name__}"
+
+        # Mutate the single rule whose destination matches our target. If
+        # the operator added more than one default-route rule (shouldn't
+        # happen — OCI rejects duplicate destinations), we update the
+        # first match and warn.
+        matches = [r for r in rules if r.get("destination") == self.failover_destination]
+        if not matches:
+            return False, f"no rule with destination={self.failover_destination!r} found in {rt_ocid}"
+        if len(matches) > 1:
+            logger.warning(
+                "%d rules match destination=%s on %s — updating first only",
+                len(matches), self.failover_destination, rt_ocid,
+            )
+
+        target = matches[0]
+        old_next_hop = target.get("network-entity-id")
+        if old_next_hop == self.local_private_ip_ocid:
+            logger.info(
+                "rt %s already next-hops to local IP %s — no-op",
+                rt_ocid, self.local_private_ip_ocid,
+            )
+            return True, "no-op (already current)"
+
+        target["network-entity-id"] = self.local_private_ip_ocid
+        target["description"] = (
+            f"Internet egress via local primary IP (VRRP master) — "
+            f"managed by oci-vrrp-failover, was {old_next_hop}"
+        )
+
+        # PUT the full modified list.
+        upd = self._run_oci([
+            "network", "route-table", "update",
+            "--rt-id", rt_ocid,
+            "--route-rules", json.dumps(rules),
+            "--force",
+        ])
+        if upd.returncode != 0:
+            return False, f"update failed: {upd.stderr.strip()}"
+        return True, "updated"
+
+    def promote(self) -> Tuple[bool, List[dict]]:
+        """Reassign all configured route tables to the local primary IP."""
+        logger.info(
+            "promoting: %d route tables → local IP %s (auth=%s, region=%s)",
+            len(self.route_table_ocids), self.local_private_ip_ocid,
+            self.auth_mode, self.region,
+        )
+        results = []
+        all_ok = True
+        for rt in self.route_table_ocids:
+            ok, message = self._update_route_table(rt)
+            results.append({"route_table": rt, "ok": ok, "message": message})
+            if not ok:
+                all_ok = False
+                logger.error("rt %s: %s", rt, message)
+            else:
+                logger.info("rt %s: %s", rt, message)
+        return all_ok, results
+
+
+def make_handler(helper: FailoverHelper) -> type:
+    """Build a request handler class closed over the configured helper."""
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        # Override the default Apache-style logger so requests appear with
+        # the same formatter as the rest of the helper's logs.
+        def log_message(self, fmt: str, *args) -> None:  # noqa: A003 (stdlib name)
+            logger.info("%s - %s", self.address_string(), fmt % args)
+
+        def _json(self, status: int, body: dict) -> None:
+            payload = json.dumps(body).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_POST(self) -> None:  # noqa: N802 (stdlib name)
+            if self.path != "/promote":
+                self._json(404, {"error": "not found"})
+                return
+            ok, results = helper.promote()
+            self._json(200 if ok else 500, {"ok": ok, "results": results})
+
+        def do_GET(self) -> None:  # noqa: N802 (stdlib name)
+            if self.path == "/health":
+                self._json(200, {
+                    "ok": True,
+                    "local_private_ip_ocid": helper.local_private_ip_ocid,
+                    "route_table_ocids": helper.route_table_ocids,
+                    "failover_destination": helper.failover_destination,
+                })
+                return
+            self._json(404, {"error": "not found"})
+
+    return Handler
+
+
+def load_config() -> FailoverHelper:
+    region = os.environ.get("OCI_REGION", "")
+    if not region:
+        raise ConfigError("OCI_REGION is required (e.g. eu-amsterdam-1)")
+
+    local_ip = os.environ.get("LOCAL_PRIVATE_IP_OCID", "")
+    if not local_ip:
+        raise ConfigError(
+            "LOCAL_PRIVATE_IP_OCID is required (this instance's primary "
+            "private IP OCID — set per-router at deploy time)"
+        )
+
+    rt_raw = os.environ.get("ROUTE_TABLE_OCIDS", "")
+    if not rt_raw:
+        raise ConfigError(
+            "ROUTE_TABLE_OCIDS is required (comma-separated list, one OCID "
+            "per route table that should next-hop to the active master)"
+        )
+    rt_list = [s.strip() for s in rt_raw.split(",") if s.strip()]
+
+    destination = os.environ.get("FAILOVER_DESTINATION", "0.0.0.0/0")
+    auth_mode = os.environ.get("OCI_AUTH", "instance_principal")
+
+    return FailoverHelper(local_ip, rt_list, region, destination, auth_mode)
+
+
+def main() -> int:
+    try:
+        helper = load_config()
+    except ConfigError as exc:
+        logger.error("startup config error: %s", exc)
+        return 2
+
+    host = os.environ.get("LISTEN_HOST", "0.0.0.0")
+    port = int(os.environ.get("LISTEN_PORT", "8080"))
+
+    logger.info(
+        "oci-vrrp-failover listening on %s:%d (region=%s, dest=%s, "
+        "local_ip=%s, route_tables=%d, auth=%s)",
+        host, port, helper.region, helper.failover_destination,
+        helper.local_private_ip_ocid, len(helper.route_table_ocids),
+        helper.auth_mode,
+    )
+    with socketserver.TCPServer((host, port), make_handler(helper)) as httpd:
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            logger.info("shutting down")
+            return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dockerfiles/oci-vrrp-failover/server.py
+++ b/dockerfiles/oci-vrrp-failover/server.py
@@ -43,7 +43,8 @@ Environment:
 Endpoints:
     POST /promote   reassign the configured route(s) to the local
                     primary private IP. Returns JSON
-                    {ok, updated, errors}.
+                    {ok, results} where results is a list of
+                    {route_table, ok, message}.
     GET  /health    liveness probe — 200 if the helper is up and
                     configured.
 

--- a/dockerfiles/oci-vrrp-failover/server.py
+++ b/dockerfiles/oci-vrrp-failover/server.py
@@ -168,10 +168,12 @@ class FailoverHelper:
             return True, "no-op (already current)"
 
         target["network-entity-id"] = self.local_private_ip_ocid
-        target["description"] = (
-            f"Internet egress via local primary IP (VRRP master) — "
-            f"managed by oci-vrrp-failover, was {old_next_hop}"
-        )
+        # Preserve original description and append a marker.
+        original_desc = target.get("description", "")
+        if original_desc:
+            target["description"] = original_desc + " [failover-managed]"
+        else:
+            target["description"] = "[failover-managed]"
 
         # PUT the full modified list.
         upd = self._run_oci([

--- a/dockerfiles/oci-vrrp-failover/test_server.py
+++ b/dockerfiles/oci-vrrp-failover/test_server.py
@@ -1,0 +1,269 @@
+"""Unit tests for the OCI VRRP failover helper.
+
+What's covered:
+- env-var parsing and validation (wrong OCID prefix is the most likely
+  copy-paste mistake when bootstrapping a new deployment)
+- the read-modify-write logic for route tables (the smoke test in the
+  design doc confirmed the OCI API shape; these tests assert the
+  helper preserves untouched rules and only swaps the matching one)
+- HTTP route surface (/promote, /health, 404)
+
+What's NOT covered:
+- actual OCI API calls (network + creds — exercised by the design doc's
+  end-to-end smoke test, which timed the real `oci network route-table
+  update` against the prod compartment at ~1.2s API / ~1.9s visible)
+- container HEALTHCHECK behaviour (covered by docker-build local test)
+"""
+
+from __future__ import annotations
+
+import json
+import socketserver
+import threading
+import unittest
+import urllib.error
+import urllib.request
+from unittest.mock import MagicMock, patch
+
+# server.py lives next to this file in the Docker build context; pytest is
+# invoked with cwd=dockerfiles/oci-vrrp-failover (see CI workflow) so the
+# relative import works.
+import server  # noqa: E402
+
+
+VALID_LOCAL_IP = "ocid1.privateip.oc1.eu-amsterdam-1.abqw2ljr6so6czsy275spwzlp73fhkxbmbqqvkcoo7k3aqonzpfdqfjbcquq"
+PEER_IP = "ocid1.privateip.oc1.eu-amsterdam-1.abqw2ljrfqk45hotftgqis5dyczbbawgl3m6hr2o2wxthklbxqlbuadddxga"
+VALID_RT_APP = "ocid1.routetable.oc1.eu-amsterdam-1.aaaaaaaapnqbav7zm6sge2he6rirutzoauj7odiultswzxufpmejgco64vga"
+VALID_RT_DATA = "ocid1.routetable.oc1.eu-amsterdam-1.aaaaaaaavob5bz6ljitzyiwzgqw53cyha6jmfgcamz6mguohnonktom6umra"
+DRG = "ocid1.drg.oc1.eu-amsterdam-1.aaaaaaaagwugj5kaivxokwwyudlfynxp7v43gspstpaufzflxyf53jxvprtq"
+
+
+def _make_rules(default_next_hop: str) -> list:
+    """Shape of the route-rules list that oci_core_route_table.app produces
+    in prod today — used as the mock return value for `route-table get`."""
+    return [
+        {
+            "cidr-block": None,
+            "description": "FranklinHouse OCI Johannesburg (DRG peering)",
+            "destination": "192.168.72.0/24",
+            "destination-type": "CIDR_BLOCK",
+            "network-entity-id": DRG,
+            "route-type": "STATIC",
+        },
+        {
+            "cidr-block": None,
+            "description": "Internet egress via MikroTik (R1)",
+            "destination": "0.0.0.0/0",
+            "destination-type": "CIDR_BLOCK",
+            "network-entity-id": default_next_hop,
+            "route-type": "STATIC",
+        },
+        {
+            "cidr-block": None,
+            "description": "Sargeant on-prem network (MikroTik)",
+            "destination": "192.168.19.0/24",
+            "destination-type": "CIDR_BLOCK",
+            "network-entity-id": DRG,
+            "route-type": "STATIC",
+        },
+    ]
+
+
+class TestFailoverHelperInit(unittest.TestCase):
+    def test_accepts_valid_inputs(self):
+        h = server.FailoverHelper(
+            VALID_LOCAL_IP, [VALID_RT_APP, VALID_RT_DATA],
+            "eu-amsterdam-1", "0.0.0.0/0", "instance_principal",
+        )
+        self.assertEqual(h.local_private_ip_ocid, VALID_LOCAL_IP)
+        self.assertEqual(h.route_table_ocids, [VALID_RT_APP, VALID_RT_DATA])
+
+    def test_rejects_local_ip_with_wrong_prefix(self):
+        with self.assertRaises(server.ConfigError) as ctx:
+            server.FailoverHelper(
+                "ocid1.vnic.oc1...", [VALID_RT_APP],
+                "eu-amsterdam-1", "0.0.0.0/0", "instance_principal",
+            )
+        self.assertIn("LOCAL_PRIVATE_IP_OCID", str(ctx.exception))
+
+    def test_rejects_rt_ocid_with_wrong_prefix(self):
+        with self.assertRaises(server.ConfigError) as ctx:
+            server.FailoverHelper(
+                VALID_LOCAL_IP, [VALID_RT_APP, "ocid1.subnet.oc1..."],
+                "eu-amsterdam-1", "0.0.0.0/0", "instance_principal",
+            )
+        self.assertIn("ROUTE_TABLE_OCIDS", str(ctx.exception))
+
+    def test_rejects_empty_rt_list(self):
+        with self.assertRaises(server.ConfigError):
+            server.FailoverHelper(
+                VALID_LOCAL_IP, [],
+                "eu-amsterdam-1", "0.0.0.0/0", "instance_principal",
+            )
+
+    def test_rejects_unknown_auth_mode(self):
+        with self.assertRaises(server.ConfigError) as ctx:
+            server.FailoverHelper(
+                VALID_LOCAL_IP, [VALID_RT_APP],
+                "eu-amsterdam-1", "0.0.0.0/0", "magic_beans",
+            )
+        self.assertIn("OCI_AUTH", str(ctx.exception))
+
+
+class TestPromote(unittest.TestCase):
+    """Read-modify-write semantics: helper must fetch existing rules,
+    flip exactly the matching destination's next-hop, and PUT the full
+    list back (preserving DRG/VPN routes)."""
+
+    def setUp(self):
+        self.helper = server.FailoverHelper(
+            VALID_LOCAL_IP, [VALID_RT_APP],
+            "eu-amsterdam-1", "0.0.0.0/0", "instance_principal",
+        )
+
+    def _mock_run(self, rules_before, update_ok=True):
+        """Return a side_effect for subprocess.run that yields the rules
+        on `get` and a success/failure on `update`."""
+        def fn(cmd, **kwargs):
+            if "get" in cmd:
+                return MagicMock(returncode=0, stdout=json.dumps(rules_before), stderr="")
+            if "update" in cmd:
+                # Inspect the --route-rules payload the helper PUTs
+                self.last_put = json.loads(cmd[cmd.index("--route-rules") + 1])
+                if update_ok:
+                    return MagicMock(returncode=0, stdout="", stderr="")
+                return MagicMock(returncode=1, stdout="", stderr="ServiceError")
+            return MagicMock(returncode=1, stdout="", stderr=f"unexpected cmd: {cmd}")
+        return fn
+
+    @patch("server.subprocess.run")
+    def test_swaps_only_matching_destination(self, mock_run):
+        rules = _make_rules(default_next_hop=PEER_IP)  # current: routes to peer
+        mock_run.side_effect = self._mock_run(rules)
+
+        ok, results = self.helper.promote()
+        self.assertTrue(ok)
+
+        # Default route now points at LOCAL_IP
+        default = next(r for r in self.last_put if r["destination"] == "0.0.0.0/0")
+        self.assertEqual(default["network-entity-id"], VALID_LOCAL_IP)
+
+        # DRG routes left untouched
+        drg_routes = [r for r in self.last_put if r["network-entity-id"] == DRG]
+        self.assertEqual(len(drg_routes), 2)
+        for r in drg_routes:
+            self.assertIn(r["destination"], ["192.168.72.0/24", "192.168.19.0/24"])
+
+    @patch("server.subprocess.run")
+    def test_no_op_when_already_current(self, mock_run):
+        rules = _make_rules(default_next_hop=VALID_LOCAL_IP)  # already routes to us
+        mock_run.side_effect = self._mock_run(rules)
+        ok, results = self.helper.promote()
+        self.assertTrue(ok)
+        # Should never have called update — only get
+        update_calls = [c for c in mock_run.call_args_list if "update" in c.args[0]]
+        self.assertEqual(len(update_calls), 0)
+        self.assertIn("no-op", results[0]["message"])
+
+    @patch("server.subprocess.run")
+    def test_propagates_oci_update_failure(self, mock_run):
+        rules = _make_rules(default_next_hop=PEER_IP)
+        mock_run.side_effect = self._mock_run(rules, update_ok=False)
+        ok, results = self.helper.promote()
+        self.assertFalse(ok)
+        self.assertIn("update failed", results[0]["message"])
+
+    @patch("server.subprocess.run")
+    def test_fails_when_no_matching_destination(self, mock_run):
+        # Construct a rule set with NO default route
+        rules = [r for r in _make_rules(default_next_hop=PEER_IP) if r["destination"] != "0.0.0.0/0"]
+        mock_run.side_effect = self._mock_run(rules)
+        ok, results = self.helper.promote()
+        self.assertFalse(ok)
+        self.assertIn("no rule with destination", results[0]["message"])
+
+    @patch("server.subprocess.run")
+    def test_partial_failure_across_multiple_route_tables(self, mock_run):
+        """Two RTs: first updates fine, second fails. Overall result = False
+        but successful one is reported as ok in the per-RT results."""
+        helper = server.FailoverHelper(
+            VALID_LOCAL_IP, [VALID_RT_APP, VALID_RT_DATA],
+            "eu-amsterdam-1", "0.0.0.0/0", "instance_principal",
+        )
+        get_call = 0
+        def fn(cmd, **kwargs):
+            nonlocal get_call
+            if "get" in cmd:
+                get_call += 1
+                return MagicMock(returncode=0, stdout=json.dumps(_make_rules(PEER_IP)), stderr="")
+            if "update" in cmd:
+                # First update OK, second fails
+                rt = cmd[cmd.index("--rt-id") + 1]
+                if rt == VALID_RT_APP:
+                    return MagicMock(returncode=0, stdout="", stderr="")
+                return MagicMock(returncode=1, stdout="", stderr="ServiceError")
+            return MagicMock(returncode=1, stdout="", stderr="bad")
+        mock_run.side_effect = fn
+
+        ok, results = helper.promote()
+        self.assertFalse(ok)
+        self.assertEqual(len(results), 2)
+        self.assertTrue(results[0]["ok"])
+        self.assertFalse(results[1]["ok"])
+
+
+class TestHttpRoutes(unittest.TestCase):
+    """Round-trip the handler against an in-process server so we exercise
+    the actual http.server dispatch, not a hand-rolled mock."""
+
+    def setUp(self):
+        helper = server.FailoverHelper(
+            VALID_LOCAL_IP, [VALID_RT_APP, VALID_RT_DATA],
+            "eu-amsterdam-1", "0.0.0.0/0", "instance_principal",
+        )
+        helper.promote = MagicMock(return_value=(True, [{"route_table": VALID_RT_APP, "ok": True, "message": "updated"}]))
+        self.helper = helper
+
+        self.httpd = socketserver.TCPServer(("127.0.0.1", 0), server.make_handler(helper))
+        self.port = self.httpd.server_address[1]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+
+    def tearDown(self):
+        self.httpd.shutdown()
+
+    def _request(self, method: str, path: str) -> tuple[int, dict]:
+        req = urllib.request.Request(f"http://127.0.0.1:{self.port}{path}", method=method)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                return resp.status, json.loads(resp.read())
+        except urllib.error.HTTPError as exc:
+            return exc.code, json.loads(exc.read())
+
+    def test_health_returns_200_with_config_echo(self):
+        status, body = self._request("GET", "/health")
+        self.assertEqual(status, 200)
+        self.assertTrue(body["ok"])
+        self.assertEqual(body["local_private_ip_ocid"], VALID_LOCAL_IP)
+        self.assertEqual(body["route_table_ocids"], [VALID_RT_APP, VALID_RT_DATA])
+        self.assertEqual(body["failover_destination"], "0.0.0.0/0")
+
+    def test_promote_returns_200_on_success(self):
+        status, body = self._request("POST", "/promote")
+        self.assertEqual(status, 200)
+        self.assertTrue(body["ok"])
+        self.helper.promote.assert_called_once()
+
+    def test_promote_returns_500_on_helper_failure(self):
+        self.helper.promote.return_value = (False, [{"route_table": VALID_RT_APP, "ok": False, "message": "update failed: ServiceError"}])
+        status, body = self._request("POST", "/promote")
+        self.assertEqual(status, 500)
+        self.assertFalse(body["ok"])
+
+    def test_unknown_path_returns_404(self):
+        status, _ = self._request("GET", "/nonexistent")
+        self.assertEqual(status, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Companion to [CalebSargeant/infra:docs/reference/oci-vrrp-ha-design.md](https://github.com/CalebSargeant/infra/blob/main/docs/reference/oci-vrrp-ha-design.md).

## What

A small Python HTTP listener + \`oci-cli\` packaged as a container, intended to run alongside \`cloudflared\` on each MikroTik CHR that's part of a two-node VRRP HA pair on OCI. When VRRP master state changes, RouterOS POSTs \`/promote\` to this listener which updates the OCI route table(s) so the default route next-hops to whichever router is currently master.

## Why route-table update and not \"move a floating private IP between VNICs\"

The original design assumed \`oci network private-ip update --vnic-id\` could re-parent a secondary IP atomically. **It can't** — that field isn't in OCI's UpdatePrivateIp API. To \"move\" a secondary IP you'd have to unassign + reassign, which creates a NEW private-ip OCID and breaks the route tables that referenced the old one.

The workable pattern is: keep the route table's \`network_entity_id\` referring to whichever **primary** private IP belongs to the active master, and update the route table on failover. A live smoke test against eu-amsterdam-1 confirmed **~1.2 s API / ~1.9 s visible** latency — comfortably under the 30 s budget.

## Layout

- \`dockerfiles/oci-vrrp-failover/Dockerfile\` — python:3.13-slim base, oci-cli from \`requirements.txt\`, non-root user, HEALTHCHECK on \`/health\`.
- \`server.py\` — stdlib \`http.server\` listener. Read-modify-write on each configured route table: GET current rules, find the rule with the configured destination (default \`0.0.0.0/0\`), swap its \`network-entity-id\` to this instance's primary private IP OCID, PUT back. No-op when already current; preserves DRG/VPN rules untouched.
- \`test_server.py\` — 14 unittest tests covering env validation, the read-modify-write semantics, partial-failure across multiple route tables, and the HTTP route surface. Mocks subprocess.run; doesn't hit OCI.
- \`README.md\` — what/why/config/IAM/local-test docs.

## CI

New workflow at \`.github/workflows/docker-publish.yml\` builds + pushes multi-arch (amd64+arm64) to \`ghcr.io/calebsargeant/oci-vrrp-failover\`, gated on changes inside \`dockerfiles/**\` and on tags of the form \`oci-vrrp-failover-v*\`. Unit tests run first; build is skipped on test failure. Separate workflow from \`build-chr.yml\` (CHR disk images and container images don't share infrastructure).

## Test plan

- [x] Unit tests pass locally: \`cd dockerfiles/oci-vrrp-failover && python3 -m unittest test_server.py -v\` → 14/14 passing.
- [x] Smoke test of the underlying OCI API done in the infra repo against the live r1/r2 → ~1.2 s API latency.
- [ ] First CI build pushes \`:latest\` to GHCR.
- [ ] Local docker build + curl test (you, with your \`~/.oci/config\` mounted).
- [ ] Pull image from MikroTik CHR via \`routeros_container\` resource (in the infra repo follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)