### PR TITLE
Onboard Chargate (security + lint)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/MagmaMoose/chargate
+    rev: v1
+    hooks:
+      - id: shellcheck
+      - id: actionlint
+      - id: hadolint
+      - id: trivy
+      - id: trufflehog
+      - id: semgrep
+      - id: checkov


### PR DESCRIPTION
Wires up [Chargate](https://github.com/MagmaMoose/chargate):
- `.pre-commit-config.yaml` — local security + lint hooks (each auto-skips if its tool isn't installed)

Part of the org-wide Chargate rollout.