### PR TITLE
fix: write first-boot config to /rw/autorun.scr (the path RouterOS runs)

### DIFF
--- a/.github/workflows/build-chr.yml
+++ b/.github/workflows/build-chr.yml
@@ -18,7 +18,7 @@ jobs:
         arch: [amd64, arm64]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: true
@@ -109,13 +109,17 @@ jobs:
           echo "Mounted image content:"
           sudo ls -lah /mnt/chr
 
-          echo "Injecting autorun.rsc into mounted image..."
-          sudo cp scripts/startup.rsc /mnt/chr/autorun.rsc
+          echo "Injecting autorun.scr into /rw on the mounted image..."
+          # RouterOS executes /rw/autorun.scr exactly once on first boot, then clears it.
+          # The image ships a stub at /rw/autorun.scr by default — we overwrite it.
+          # A file at the partition root or named .rsc is NOT executed (this was the bug).
+          sudo mkdir -p /mnt/chr/rw
+          sudo cp scripts/startup.rsc /mnt/chr/rw/autorun.scr
 
           echo "Confirming injection:"
-          sudo ls -lah /mnt/chr/autorun.rsc
+          sudo ls -lah /mnt/chr/rw/autorun.scr
           echo "File contents:"
-          sudo cat /mnt/chr/autorun.rsc
+          sudo cat /mnt/chr/rw/autorun.scr
 
           echo "Unmounting and detaching loop device..."
           sudo umount /mnt/chr
@@ -144,7 +148,7 @@ jobs:
 
       - name: Create or update GitHub Release
         if: steps.check.outputs.skip == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: v${{ steps.get-version.outputs.version }}-${{ matrix.arch }}
           name: "MikroTik CHR ${{ steps.get-version.outputs.version }} (${{ matrix.arch }})"

--- a/scripts/inject.sh
+++ b/scripts/inject.sh
@@ -1,27 +1,52 @@
 #!/bin/bash
-set -e
+# inject.sh - Inject startup config into a CHR raw image as /rw/autorun.scr
+#
+# Usage: sudo ./scripts/inject.sh [chr-image.img]   (default: chr.img)
+#
+# RouterOS executes /rw/autorun.scr exactly once on first boot, then clears it.
+# The file MUST be under rw/ with the .scr extension on the writable partition
+# (ext3, volume label "RouterOS"). A file at the partition root, or named .rsc,
+# is NOT executed — that was the previous bug (and why "the startup did nothing").
+set -euo pipefail
 
-echo "Extracting CHR image..."
-# Extract the CHR image using 7z
-7z x chr.img -o./chr_extract
+IMG="${1:-chr.img}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STARTUP="${SCRIPT_DIR}/startup.rsc"
 
-echo "Creating directory structure if needed..."
-mkdir -p ./chr_extract/router/rw/store/
+if [[ $EUID -ne 0 ]]; then
+    echo "❌ Must run as root (needs losetup/mount). Try: sudo $0 $*"
+    exit 1
+fi
+[[ -f "$IMG" ]]     || { echo "❌ Image not found: $IMG"; exit 1; }
+[[ -f "$STARTUP" ]] || { echo "❌ startup.rsc not found: $STARTUP"; exit 1; }
 
-echo "Injecting startup script..."
-cp scripts/startup.rsc ./chr_extract/router/rw/store/
+MNT="$(mktemp -d)"
+LOOP="$(losetup --show -Pf "$IMG")"
+cleanup() {
+    umount "$MNT" 2>/dev/null || true
+    losetup -d "$LOOP" 2>/dev/null || true
+    rmdir "$MNT" 2>/dev/null || true
+}
+trap cleanup EXIT
 
-echo "Repacking the image..."
-# Navigate to the extraction directory
-cd ./chr_extract
+# Find the writable partition (the one containing rw/) instead of hardcoding p2,
+# so this survives image layout changes.
+found=""
+for part in "${LOOP}"p{1..8}; do
+    [[ -e "$part" ]] || continue
+    mount "$part" "$MNT" 2>/dev/null || continue
+    if [[ -d "$MNT/rw" ]]; then
+        found="$part"
+        break
+    fi
+    umount "$MNT" 2>/dev/null || true
+done
+[[ -n "$found" ]] || { echo "❌ Could not find the rw/ partition in $IMG"; exit 1; }
+echo "Using writable partition: $found"
 
-# Repack only the RouterOS.img file (which contains the router directory)
-7z a -tzip ../modified-RouterOS.img ./router/
+cp "$STARTUP" "$MNT/rw/autorun.scr"
+echo "Injected /rw/autorun.scr:"
+cat "$MNT/rw/autorun.scr"
+sync
 
-# Move back to the original directory
-cd ..
-
-# Replace the original RouterOS.img in chr.img with our modified version
-7z u chr.img modified-RouterOS.img
-
-echo "✅ Startup script injected successfully"
+echo "✅ Startup script injected successfully as /rw/autorun.scr"

--- a/scripts/startup.rsc
+++ b/scripts/startup.rsc
@@ -1,16 +1,24 @@
-:log info "Running autorun.rsc - CHR Multi-Architecture Image"
-/system/identity set name=chr
+# First-boot configuration for CHR cloud images.
+# Injected offline as /rw/autorun.scr on partition 2 (ext3 "RouterOS") of the raw image.
+# RouterOS reads /rw/autorun.scr exactly once on first boot, runs each line as a
+# console command, then clears it. NOTE: the file MUST be /rw/autorun.scr (.scr, under
+# rw/) — a file at the partition root or named .rsc is NOT executed.
+:log info "Running autorun.scr - CHR Multi-Architecture Image"
 
-# Enable interfaces for proper network access
+# Set admin password FIRST. RouterOS v7 forces an interactive "expired password"
+# change on the first login of a blank-password user, which would otherwise block
+# automated SSH/password access. Setting it here (system context, not a login) disarms it.
+/user set admin password="PLACEHOLDER_PASSWORD"
+
+/system identity set name=chr
+
+# Enable management services for cloud access
 /ip service enable ssh
-/ip service enable api-ssl
 /ip service set ssh port=22
+/ip service enable api-ssl
 /ip service set api-ssl port=8729
 
-# Enable DHCP client on ether1 (common EC2/cloud setup)
+# Enable DHCP client on ether1 (standard cloud/EC2/OCI setup)
 /ip dhcp-client add interface=ether1 disabled=no
-
-# Set admin password (will be replaced by build process with rotating password)
-/user/set admin password="PLACEHOLDER_PASSWORD"
 
 :log info "CHR configuration applied successfully"


### PR DESCRIPTION
## The bug

The injected first-boot config never executed — "the startup does nothing". RouterOS only runs **`/rw/autorun.scr`** on first boot (verified against a live CHR 7.23.1 image, which ships a 2-byte stub there by default). But:

- `build-chr.yml` injected to `/autorun.rsc` at the **partition root** (wrong path + `.rsc` instead of `.scr`)
- `inject.sh` wrote to `router/rw/store/startup.rsc` (RouterOS's file store — never auto-run)

So the identity / SSH / DHCP / password lines were never applied; released images booted as stock CHR.

## The fix

- **`build-chr.yml`** — inject to `/rw/autorun.scr` (partition 2, the ext3 "RouterOS" partition)
- **`inject.sh`** — rewritten to loop-mount + write `/rw/autorun.scr`, finding the writable partition by looking for `rw/` (robust against layout changes) instead of the old 7z-extract approach
- **`startup.rsc`** — set the admin password **first** to disarm the RouterOS v7 first-login expired-password prompt, which otherwise blocks automated SSH/password login

Verified end-to-end: a CHR booted from an image built this way comes up with the config applied (identity, SSH, DHCP, password) and is reachable.
